### PR TITLE
docs(README): remind to select open source NVIDIA driver during install for patch compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ address over DMA.
    - Add `amd_iommu=on iommu=pt` to `GRUB_CMDLINE_LINUX_DEFAULT` (use `intel_iommu=on iommu=pt` on Intel)
    - Run `sudo update-grub`
 2. Install the [NVIDIA 610.43.02 driver](https://www.nvidia.com/en-us/drivers/details/271414/)
+   - **When installing the driver, select the open source driver** so we can modify it with the patch.
 3. Run `./install.sh` in this repo
 4. Reboot the server
 


### PR DESCRIPTION
    When installing the NVIDIA 610.43.02 driver, users must select the open source driver variant so that the kernel module source can be patched by this repo. Without selecting the open source driver, the patches in this repository will not apply correctly.
    
    Added this note as a sub-bullet under step 2 ("Install the NVIDIA 610.43.02 driver") in the "How to use" section.