### PR TITLE
P2P TailReserve

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,40 @@
 # NVIDIA driver 610.57.04 with P2P for RTX 3090, RTX 4090, and RTX 5090
 
-This enables P2P on consumer GPUs with the 610.57.04 driver version. No kernel parameters
-are needed for the default behavior, just build, install, and go.
+This enables NVLink and PCIe BAR1 P2P on consumer GPUs with the 610.57.04 driver,
+including mixed-generation pairs such as RTX 3090 to RTX 5090. No NVIDIA module
+parameter is needed for the default behavior, but PCIe BAR1 P2P requires Resizable BAR
+and an IOMMU configured for passthrough.
 
 See the [tinygrad 550.54.15-p2p README](https://github.com/tinygrad/open-gpu-kernel-modules/blob/550.54.15-p2p/README.md)
 for the original description of the approach.
 
 ## Supported configurations
 
-| GPU      | P2P path                                                               |
-| -------- | ---------------------------------------------------------------------- |
-| RTX 3090 | Pairwise NVLink where available, PCIe BAR1 otherwise                   |
-| RTX 4090 | PCIe BAR1                                                              |
-| RTX 5090 | PCIe BAR1                                                              |
+| GPUs                      | P2P path                                     |
+| ------------------------- | -------------------------------------------- |
+| RTX 3090 pair             | NVLink where available, PCIe BAR1 otherwise |
+| RTX 4090 or RTX 5090 pair | PCIe BAR1                                    |
+| Mixed-generation pair     | PCIe BAR1 + `libcuda` patch                  |
 
-P2P also works between different devices of the same generation, for example RTX 5090
-to RTX PRO 6000 Blackwell.
+Same-generation devices need only the patched kernel modules. Mixed-generation CUDA
+P2P also needs the user-space patch described below. Different devices from the same
+generation work, for example RTX 5090 to RTX PRO 6000 Blackwell.
+
+PCIe BAR1 P2P requires a sufficiently large BAR1 aperture on every participating GPU.
+Consumer Turing GPUs do not provide the required Resizable BAR support and are not
+supported by this path.
 
 ## How it works
 
-This enables BAR1 P2P on consumer GPUs where NVLink isn't available, and falls back to
+This enables BAR1 P2P on consumer GPUs where NVLink is not available, while retaining
 NVLink where it is. For PCIe pairs, transfers write directly to the other GPU's physical
 address over DMA.
+
+The mixed-generation changes treat BAR1 as independent from NVIDIA's
+architecture-specific proprietary PCIe mailbox protocol, enable dynamic BAR1 peer
+mappings on Ampere and Ada, and track those mappings so they can be freed correctly.
+Mixed-architecture mappings are kept non-coherent; BAR1 atomics are not advertised for
+them.
 
 > [!WARNING]
 > IOMMU must be in passthrough mode (`iommu=pt`), not translating, or DMA will go through
@@ -30,13 +43,26 @@ address over DMA.
 
 ## How to use
 
-1. Enable DMA passthrough mode for the IOMMU:
+1. Enable Above 4G Decoding and Resizable BAR in system firmware.
+2. Enable DMA passthrough mode for the IOMMU:
    - Edit `/etc/default/grub`
    - Add `amd_iommu=on iommu=pt` to `GRUB_CMDLINE_LINUX_DEFAULT` (use `intel_iommu=on iommu=pt` on Intel)
    - Run `sudo update-grub`
-2. Install the [NVIDIA 610.57.04 driver](https://www.nvidia.com/en-us/drivers/details/274513/)
-3. Run `./install.sh` in this repo
-4. Reboot the server
+3. Install the [NVIDIA 610.57.04 driver](https://www.nvidia.com/en-us/drivers/details/274513/).
+4. Run `./install.sh` in this repo.
+5. For mixed-generation P2P, back up and patch the system `libcuda` as described below.
+6. Reboot the server.
+
+## Mixed-generation `libcuda` patch
+
+The proprietary `libcuda` also blocks mixed-generation P2P. Set the correct path
+for your installation, back it up, and run [`patch-libcuda-p2p.py`](patch-libcuda-p2p.py):
+
+```
+LIBCUDA=/usr/lib/x86_64-linux-gnu/libcuda.so.1
+sudo cp "$LIBCUDA" "$LIBCUDA.bak"
+sudo ./patch-libcuda-p2p.py "$LIBCUDA"
+```
 
 ## Forcing 3090s to use PCIe instead of NVLink
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,248 @@
+# NVIDIA driver 610.57.04 with P2P for RTX 3090, RTX 4090, and RTX 5090
+
+This enables P2P on consumer GPUs with the 610.57.04 driver version. No kernel parameters
+are needed for the default behavior, just build, install, and go.
+
+See the [tinygrad 550.54.15-p2p README](https://github.com/tinygrad/open-gpu-kernel-modules/blob/550.54.15-p2p/README.md)
+for the original description of the approach.
+
+## Supported configurations
+
+| GPU      | P2P path                                                               |
+| -------- | ---------------------------------------------------------------------- |
+| RTX 3090 | Pairwise NVLink where available, PCIe BAR1 otherwise                   |
+| RTX 4090 | PCIe BAR1                                                              |
+| RTX 5090 | PCIe BAR1                                                              |
+
+P2P also works between different devices of the same generation, for example RTX 5090
+to RTX PRO 6000 Blackwell.
+
+## How it works
+
+This enables BAR1 P2P on consumer GPUs where NVLink isn't available, and falls back to
+NVLink where it is. For PCIe pairs, transfers write directly to the other GPU's physical
+address over DMA.
+
+> [!WARNING]
+> IOMMU must be in passthrough mode (`iommu=pt`), not translating, or DMA will go through
+> IOMMU page tables and transfers will fail. This is very dangerous if you run untrusted
+> software or devices.
+
+## How to use
+
+1. Enable DMA passthrough mode for the IOMMU:
+   - Edit `/etc/default/grub`
+   - Add `amd_iommu=on iommu=pt` to `GRUB_CMDLINE_LINUX_DEFAULT` (use `intel_iommu=on iommu=pt` on Intel)
+   - Run `sudo update-grub`
+2. Install the [NVIDIA 610.57.04 driver](https://www.nvidia.com/en-us/drivers/details/274513/)
+3. Run `./install.sh` in this repo
+4. Reboot the server
+
+## Forcing 3090s to use PCIe instead of NVLink
+
+For testing, you can make 3090 pairs fall back to PCIe BAR1 even when NVLink is present by
+passing `NVreg_RegistryDwords="RMForceP2PType=1"` to the nvidia module. Add this to
+`/etc/modprobe.d/nvidia.conf`:
+
+```
+options nvidia NVreg_RegistryDwords="RMForceP2PType=1"
+```
+
+## Experimental: faster cudaHostRegister for hugepage-backed memory
+
+This branch also includes an experimental path that accelerates `cudaHostRegister` by
+several orders of magnitude when the registered buffer is backed by 1G hugepages, and
+shrinks the device page tables used for such mappings. It is enabled automatically. This
+path skips some of the per-4K-page bookkeeping the stock driver performs, so it may
+misbehave in edge cases the stock driver handles correctly.
+
+## Potential issues
+
+If P2P transfers are slow, make sure your IOMMU is in passthrough (`pt`) mode and that ACS
+is disabled. ACS on root ports forces all GPU-to-GPU traffic through the CPU root complex,
+killing P2P bandwidth. ACS can be disabled in BIOS, with the
+`pcie_acs_override=downstream,multifunction` kernel parameter (if your kernel supports it),
+or with an ACS override patch applied to the kernel.
+
+## Sample `p2pBandwidthLatencyTest` output
+
+9-GPU system (1x RTX PRO 6000 Blackwell + 8x RTX 5090) on a dual-socket AMD EPYC 9575F (Turin) host:
+
+```
+./p2pBandwidthLatencyTest
+```
+
+```
+[P2P (Peer-to-Peer) GPU Bandwidth Latency Test]
+Device: 0, NVIDIA RTX PRO 6000 Blackwell Workstation Edition, pciBusID: c1, pciDeviceID: 0, pciDomainID:0
+Device: 1, NVIDIA GeForce RTX 5090, pciBusID: 1, pciDeviceID: 0, pciDomainID:0
+Device: 2, NVIDIA GeForce RTX 5090, pciBusID: 11, pciDeviceID: 0, pciDomainID:0
+Device: 3, NVIDIA GeForce RTX 5090, pciBusID: 61, pciDeviceID: 0, pciDomainID:0
+Device: 4, NVIDIA GeForce RTX 5090, pciBusID: 71, pciDeviceID: 0, pciDomainID:0
+Device: 5, NVIDIA GeForce RTX 5090, pciBusID: 81, pciDeviceID: 0, pciDomainID:0
+Device: 6, NVIDIA GeForce RTX 5090, pciBusID: 91, pciDeviceID: 0, pciDomainID:0
+Device: 7, NVIDIA GeForce RTX 5090, pciBusID: e1, pciDeviceID: 0, pciDomainID:0
+Device: 8, NVIDIA GeForce RTX 5090, pciBusID: f1, pciDeviceID: 0, pciDomainID:0
+
+***NOTE: In case a device doesn't have P2P access to other one, it falls back to normal memcopy procedure.
+So you can see lesser Bandwidth (GB/s) and unstable Latency (us) in those cases.
+
+P2P Connectivity Matrix
+     D\D     0     1     2     3     4     5     6     7     8
+     0	     1     1     1     1     1     1     1     1     1
+     1	     1     1     1     1     1     1     1     1     1
+     2	     1     1     1     1     1     1     1     1     1
+     3	     1     1     1     1     1     1     1     1     1
+     4	     1     1     1     1     1     1     1     1     1
+     5	     1     1     1     1     1     1     1     1     1
+     6	     1     1     1     1     1     1     1     1     1
+     7	     1     1     1     1     1     1     1     1     1
+     8	     1     1     1     1     1     1     1     1     1
+Unidirectional P2P=Disabled Bandwidth Matrix (GB/s)
+   D\D     0      1      2      3      4      5      6      7      8 
+     0 1611.24  43.30  42.82  42.88  42.89  43.69  43.61  43.63  43.74 
+     1  43.38 1658.76  42.71  42.69  42.83  43.34  43.47  43.33  43.50 
+     2  43.53  42.82 1664.06  42.71  42.74  43.19  43.31  43.24  43.34 
+     3  43.51  42.91  42.80 1660.58  42.77  43.20  43.27  43.17  43.36 
+     4  43.47  43.00  42.83  42.82 1664.06  43.43  43.32  43.32  43.49 
+     5  43.81  42.95  42.84  42.84  42.94 1665.83  43.52  43.45  43.48 
+     6  43.76  43.04  42.93  42.99  43.01  43.85 1662.29  43.66  43.74 
+     7  43.77  42.95  42.90  43.10  43.00  43.85  43.77 1662.29  43.74 
+     8  43.84  43.08  43.04  43.03  43.25  43.91  43.87  43.89 1658.70 
+Unidirectional P2P=Enabled Bandwidth (P2P Writes) Matrix (GB/s)
+   D\D     0      1      2      3      4      5      6      7      8 
+     0 1617.49  55.59  55.62  55.64  55.64  56.58  56.58  56.58  56.58 
+     1  55.60 1656.95  56.57  56.55  56.57  55.63  55.63  55.62  55.64 
+     2  55.63  56.55 1660.47  56.55  56.57  55.62  55.62  55.63  55.61 
+     3  55.63  56.58  56.55 1658.70  56.55  55.63  55.63  55.59  55.63 
+     4  55.63  56.55  56.58  56.58 1656.95  55.62  55.61  55.61  55.64 
+     5  56.57  55.62  55.62  55.64  55.64 1662.23  56.55  56.58  56.58 
+     6  56.50  55.62  55.62  55.61  55.64  56.58 1662.23  56.58  56.58 
+     7  56.58  55.62  55.62  55.64  55.65  56.58  56.58 1665.78  56.57 
+     8  56.55  55.62  55.62  55.64  55.63  56.58  56.55  56.58 1662.23 
+Bidirectional P2P=Disabled Bandwidth Matrix (GB/s)
+   D\D     0      1      2      3      4      5      6      7      8 
+     0 1600.87  56.70  56.88  57.10  56.47  57.06  56.93  57.22  57.30 
+     1  57.17 1642.93  56.50  56.74  56.48  57.19  56.77  56.87  56.75 
+     2  56.87  56.90 1645.55  56.69  56.67  56.93  57.00  56.76  56.83 
+     3  56.95  56.85  56.50 1640.37  56.66  56.78  56.98  57.48  57.40 
+     4  56.50  56.25  56.58  56.61 1644.68  57.09  57.05  56.91  57.09 
+     5  57.31  56.94  56.67  56.83  56.78 1642.06  57.21  57.17  57.47 
+     6  56.85  56.95  56.87  56.99  56.64  57.29 1642.09  57.09  57.02 
+     7  57.15  57.05  56.85  56.54  56.95  56.71  57.20 1646.42  56.96 
+     8  57.00  56.73  57.09  56.82  56.49  57.08  56.90  57.06 1642.95 
+Bidirectional P2P=Enabled Bandwidth Matrix (GB/s)
+   D\D     0      1      2      3      4      5      6      7      8 
+     0 1600.87 111.17 111.04 111.14 111.12 111.35 111.34 111.39 111.38 
+     1 111.12 1636.90 111.38 111.39 111.34 111.10 111.08 111.11 111.08 
+     2 111.08 111.38 1639.51 111.41 111.38 111.08 110.95 111.13 110.98 
+     3 111.13 111.40 111.39 1641.23 111.39 111.12 111.15 110.83 111.09 
+     4 111.13 111.40 111.34 111.40 1642.95 111.07 111.12 111.15 111.11 
+     5 111.35 111.13 111.11 111.15 110.97 1640.34 111.45 111.39 111.43 
+     6 111.45 111.01 111.09 111.14 111.17 111.39 1642.95 111.39 111.45 
+     7 111.45 111.11 111.18 111.12 111.17 111.40 111.40 1640.37 111.40 
+     8 111.34 111.19 111.10 111.04 111.17 111.39 111.40 111.39 1637.76 
+P2P=Disabled Latency Matrix (us)
+   GPU     0      1      2      3      4      5      6      7      8 
+     0   1.04  14.31  14.22  14.35  14.30  14.05  14.22   7.98  14.35 
+     1  14.44   0.98  14.31  14.31  14.31  14.32  14.30  14.32  14.34 
+     2  14.32  14.31   0.98  14.32  14.31  14.30  14.31  14.32  14.35 
+     3  14.32  14.32  14.32   1.01  14.32  14.31  14.32  14.32  14.32 
+     4  14.33  14.31  14.32  14.30   0.97  14.30  14.32  14.31  14.33 
+     5  14.33  14.24  14.31  14.16  14.15   0.95  14.32  14.32  14.31 
+     6  12.61  14.06  14.32  14.32  14.33  14.33   0.98  14.32  14.32 
+     7  14.33  14.33  14.30  14.32  14.26  14.33  14.24   0.92  12.56 
+     8  12.51  14.32  14.22  14.31  14.32  14.25  14.33  14.31   0.96 
+
+   CPU     0      1      2      3      4      5      6      7      8 
+     0   1.76   5.83   6.08   5.98   5.66   4.93   5.29   5.23   4.88 
+     1   5.48   1.87   6.36   6.34   6.04   5.30   5.60   5.58   5.26 
+     2   5.70   6.24   2.01   6.56   6.26   5.48   5.87   5.83   5.46 
+     3   5.64   6.27   6.54   2.00   6.24   5.52   5.83   5.79   5.45 
+     4   5.46   6.03   6.34   6.31   1.89   5.31   5.62   5.59   5.24 
+     5   4.93   5.50   5.84   5.83   5.48   1.62   5.12   5.08   4.76 
+     6   5.15   5.71   6.04   6.04   5.74   4.98   1.75   5.34   4.97 
+     7   5.11   5.73   5.99   5.99   5.71   5.02   5.32   1.73   4.97 
+     8   4.93   5.47   5.78   5.80   5.48   4.74   5.05   5.05   1.63 
+P2P=Enabled Latency (P2P Writes) Matrix (us)
+   GPU     0      1      2      3      4      5      6      7      8 
+     0   1.02   0.38   0.42   0.36   0.37   0.37   0.44   0.36   0.36 
+     1   0.45   0.98   0.37   0.44   0.38   0.43   0.45   0.45   0.39 
+     2   0.37   0.38   0.96   0.36   0.38   0.37   0.38   0.38   0.38 
+     3   0.44   0.44   0.43   1.01   0.38   0.37   0.45   0.38   0.44 
+     4   0.43   0.36   0.37   0.37   0.95   0.35   0.38   0.44   0.44 
+     5   0.37   0.36   0.36   0.36   0.35   0.95   0.36   0.36   0.36 
+     6   0.36   0.43   0.43   0.36   0.43   0.36   0.98   0.43   0.36 
+     7   0.37   0.35   0.36   0.35   0.36   0.36   0.43   0.92   0.43 
+     8   0.38   0.44   0.36   0.44   0.37   0.38   0.37   0.37   0.96 
+
+   CPU     0      1      2      3      4      5      6      7      8 
+     0   1.75   1.34   1.31   1.31   1.31   1.32   1.36   1.32   1.31 
+     1   1.52   1.88   1.49   1.53   1.52   1.53   1.52   1.58   1.52 
+     2   1.67   1.64   2.04   1.64   1.64   1.65   1.65   1.64   1.66 
+     3   1.66   1.63   1.63   2.00   1.64   1.63   1.64   1.63   1.63 
+     4   1.55   1.53   1.53   1.53   1.93   1.53   1.54   1.53   1.53 
+     5   1.32   1.31   1.30   1.30   1.31   1.68   1.30   1.31   1.30 
+     6   1.42   1.39   1.40   1.41   1.41   1.41   1.77   1.41   1.41 
+     7   1.42   1.39   1.45   1.39   1.39   1.40   1.40   1.74   1.40 
+     8   1.33   1.28   1.29   1.32   1.30   1.29   1.29   1.30   1.66 
+```
+
+## Sample `nccl-tests` `all_reduce_perf` output
+
+8x RTX 5090 on the same host:
+
+```
+CUDA_VISIBLE_DEVICES=1,2,3,4,5,6,7,8 NCCL_P2P_LEVEL=SYS ./build/all_reduce_perf -b 8 -e 128M -f 2 -g 8
+```
+
+```
+# nccl-tests version 2.18.2 nccl-headers=22907 nccl-library=22907
+# Collective test starting: all_reduce_perf
+# nThread 1 nGpus 8 minBytes 8 maxBytes 134217728 step: 2(factor) warmup iters: 1 iters: 20 agg iters: 1 validation: 1 graph: 0 unalign: 0
+#
+# Using devices
+#  Rank  0 Group  0 Pid  27238 on      crazy device  0 [0000:01:00] NVIDIA GeForce RTX 5090
+#  Rank  1 Group  0 Pid  27238 on      crazy device  1 [0000:11:00] NVIDIA GeForce RTX 5090
+#  Rank  2 Group  0 Pid  27238 on      crazy device  2 [0000:61:00] NVIDIA GeForce RTX 5090
+#  Rank  3 Group  0 Pid  27238 on      crazy device  3 [0000:71:00] NVIDIA GeForce RTX 5090
+#  Rank  4 Group  0 Pid  27238 on      crazy device  4 [0000:81:00] NVIDIA GeForce RTX 5090
+#  Rank  5 Group  0 Pid  27238 on      crazy device  5 [0000:91:00] NVIDIA GeForce RTX 5090
+#  Rank  6 Group  0 Pid  27238 on      crazy device  6 [0000:e1:00] NVIDIA GeForce RTX 5090
+#  Rank  7 Group  0 Pid  27238 on      crazy device  7 [0000:f1:00] NVIDIA GeForce RTX 5090
+#
+#                                                              out-of-place                       in-place          
+#       size         count      type   redop    root     time   algbw   busbw  #wrong     time   algbw   busbw  #wrong 
+#        (B)    (elements)                               (us)  (GB/s)  (GB/s)             (us)  (GB/s)  (GB/s)         
+           8             2     float     sum      -1    25.47    0.00    0.00       0    24.82    0.00    0.00       0
+          16             4     float     sum      -1    24.52    0.00    0.00       0    24.60    0.00    0.00       0
+          32             8     float     sum      -1    24.65    0.00    0.00       0    24.70    0.00    0.00       0
+          64            16     float     sum      -1    24.72    0.00    0.00       0    24.78    0.00    0.00       0
+         128            32     float     sum      -1    24.67    0.01    0.01       0    24.79    0.01    0.01       0
+         256            64     float     sum      -1    24.77    0.01    0.02       0    24.56    0.01    0.02       0
+         512           128     float     sum      -1    24.62    0.02    0.04       0    24.62    0.02    0.04       0
+        1024           256     float     sum      -1    24.66    0.04    0.07       0    24.65    0.04    0.07       0
+        2048           512     float     sum      -1    24.54    0.08    0.15       0    24.66    0.08    0.15       0
+        4096          1024     float     sum      -1    36.29    0.11    0.20       0    35.21    0.12    0.20       0
+        8192          2048     float     sum      -1    37.00    0.22    0.39       0    36.06    0.23    0.40       0
+       16384          4096     float     sum      -1    38.06    0.43    0.75       0    37.14    0.44    0.77       0
+       32768          8192     float     sum      -1    39.33    0.83    1.46       0    38.42    0.85    1.49       0
+       65536         16384     float     sum      -1    40.96    1.60    2.80       0    40.07    1.64    2.86       0
+      131072         32768     float     sum      -1    42.19    3.11    5.44       0    41.28    3.18    5.56       0
+      262144         65536     float     sum      -1    45.87    5.71   10.00       0    45.00    5.83   10.19       0
+      524288        131072     float     sum      -1    56.96    9.20   16.11       0    57.42    9.13   15.98       0
+     1048576        262144     float     sum      -1    74.74   14.03   24.55       0    72.38   14.49   25.35       0
+     2097152        524288     float     sum      -1   104.50   20.07   35.12       0   107.73   19.47   34.07       0
+     4194304       1048576     float     sum      -1   176.93   23.71   41.48       0   178.56   23.49   41.11       0
+     8388608       2097152     float     sum      -1   326.13   25.72   45.01       0   336.41   24.94   43.64       0
+    16777216       4194304     float     sum      -1   646.48   25.95   45.42       0   647.96   25.89   45.31       0
+    33554432       8388608     float     sum      -1  1284.81   26.12   45.70       0  1286.28   26.09   45.65       0
+    67108864      16777216     float     sum      -1  2585.56   25.96   45.42       0  2583.09   25.98   45.47       0
+   134217728      33554432     float     sum      -1  5355.16   25.06   43.86       0  5329.43   25.18   44.07       0
+```
+
+---
+
 # NVIDIA Linux Open GPU Kernel Module Source
 
 This is the source release of the NVIDIA Linux open GPU kernel modules,

--- a/patch-libcuda-p2p.py
+++ b/patch-libcuda-p2p.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Persistently patch libcuda for mixed-generation P2P support."""
+
+from pathlib import Path
+import re
+import sys
+
+
+# Each rewrite is (byte offset in the signature, replacement bytes).
+PATCHES = (
+    (
+        "can-access predicate",
+        """
+        48 8b 83 50 0c 00 00     # mov rax, qword ptr [rbx + 0xc50]
+        49 8b 94 24 50 0c 00 00  # mov rdx, qword ptr [r12 + 0xc50]
+        48 39 d0                 # cmp rax, rdx
+        74 ??                    # je 0x44 -> jmp 0x44
+        48 3d c0 00 00 00        # cmp rax, 0xc0
+        75 ??                    # jne 0x9
+        48 81 fa c8 00 00 00     # cmp rdx, 0xc8
+        74 ??                    # je 0x33
+        48 3d c8 00 00 00        # cmp rax, 0xc8
+        75 ??                    # jne 0x9
+        48 81 fa c0 00 00 00     # cmp rdx, 0xc0
+        74 ??                    # je 0x22
+        83 e0 f0                 # and eax, -0x10
+        48 3d f0 00 00 00        # cmp rax, 0xf0
+        74 ??                    # je 0xb
+        31 c0                    # xor eax, eax
+        """,
+        (18, b"\xeb"),
+    ),
+    (
+        "compatibility predicate",
+        """
+        48 8b 87 50 0c 00 00  # mov rax, qword ptr [rdi + 0xc50]
+        48 8b 93 50 0c 00 00  # mov rdx, qword ptr [rbx + 0xc50]
+        48 39 d0              # cmp rax, rdx
+        74 ??                 # je 0x45 -> jmp 0x45
+        48 3d c0 00 00 00     # cmp rax, 0xc0
+        75 ??                 # jne 0x9
+        48 81 fa c8 00 00 00  # cmp rdx, 0xc8
+        74 ??                 # je 0x34
+        48 3d c8 00 00 00     # cmp rax, 0xc8
+        75 ??                 # jne 0x9
+        48 81 fa c0 00 00 00  # cmp rdx, 0xc0
+        74 ??                 # je 0x23
+        83 e0 f0              # and eax, -0x10
+        48 3d f0 00 00 00     # cmp rax, 0xf0
+        75 ??                 # jne 0xc
+        83 e2 f0              # and edx, -0x10
+        """,
+        (17, b"\xeb"),
+    ),
+    (
+        "peer-device selection",
+        """
+        49 8b 87 50 0c 00 00  # mov rax, qword ptr [r15 + 0xc50]
+        49 8b 96 50 0c 00 00  # mov rdx, qword ptr [r14 + 0xc50]
+        48 39 d0              # cmp rax, rdx
+        0f 84 ?? ?? ?? ??     # je 0x87 -> nop; jmp 0x87
+        48 81 fa c8 00 00 00  # cmp rdx, 0xc8
+        75 ??                 # jne 0x8
+        48 3d c0 00 00 00     # cmp rax, 0xc0
+        74 ??                 # je 0x76
+        48 81 fa c0 00 00 00  # cmp rdx, 0xc0
+        75 ??                 # jne 0x8
+        48 3d c8 00 00 00     # cmp rax, 0xc8
+        74 ??                 # je 0x65
+        83 e0 f0              # and eax, -0x10
+        48 3d f0 00 00 00     # cmp rax, 0xf0
+        74 ??                 # je 0x4e
+        """,
+        (17, b"\x90\xe9"),
+    ),
+    (
+        "peer setup",
+        """
+        49 8b 84 24 50 0c 00 00  # mov rax, qword ptr [r12 + 0xc50]
+        49 8b 95 50 0c 00 00     # mov rdx, qword ptr [r13 + 0xc50]
+        48 39 d0                 # cmp rax, rdx
+        74 ??                    # je 0x6a -> jmp 0x6a
+        48 3d c0 00 00 00        # cmp rax, 0xc0
+        75 ??                    # jne 0x9
+        48 81 fa c8 00 00 00     # cmp rdx, 0xc8
+        74 ??                    # je 0x59
+        48 81 fa c0 00 00 00     # cmp rdx, 0xc0
+        75 ??                    # jne 0x8
+        48 3d c8 00 00 00        # cmp rax, 0xc8
+        74 ??                    # je 0x48
+        83 e0 f0                 # and eax, -0x10
+        48 3d f0 00 00 00        # cmp rax, 0xf0
+        75 ??                    # jne 0x15
+        83 e2 f0                 # and edx, -0x10
+        """,
+        (18, b"\xeb"),
+    ),
+)
+
+
+if len(sys.argv) != 2:
+    raise SystemExit(f"usage: {sys.argv[0]} LIBCUDA")
+
+source = Path(sys.argv[1])
+data = bytearray(source.read_bytes())
+changes = []
+
+for name, signature, (branch, replacement) in PATCHES:
+    tokens = re.sub(r"#.*", "", signature).split()
+    pattern = b"".join(
+        b"." if token == "??" else re.escape(bytes.fromhex(token))
+        for token in tokens
+    )
+    matches = list(re.finditer(pattern, data, re.DOTALL))
+    if len(matches) != 1:
+        raise SystemExit(f"error: {name} signature matched {len(matches)} times instead of once")
+
+    offset = matches[0].start() + branch
+    data[offset:offset + len(replacement)] = replacement
+    changes.append((name, offset, replacement))
+
+with source.open("r+b") as library:
+    for _, offset, replacement in changes:
+        library.seek(offset)
+        library.write(replacement)
+
+for name, offset, _ in changes:
+    print(f"applied: {name} at 0x{offset:x}")

--- a/src/nvidia/generated/g_virt_mem_allocator_nvoc.c
+++ b/src/nvidia/generated/g_virt_mem_allocator_nvoc.c
@@ -330,8 +330,9 @@ static void __nvoc_init_funcTable_VirtMemAllocator_1(VirtMemAllocator *pThis, Gp
     }
 
     // dmaAllocBar1P2PMapping -- halified (2 hals) body
-    if (( ((chipHal_HalVarIdx >> 5) == 1UL) && ((1UL << (chipHal_HalVarIdx & 0x1f)) & 0xbc000000UL) ) ||
-        ( ((chipHal_HalVarIdx >> 5) == 2UL) && ((1UL << (chipHal_HalVarIdx & 0x1f)) & 0x000030ffUL) )) /* ChipHal: GH100 | GB100 | GB102 | GB10B | GB110 | GB112 | GB202 | GB203 | GB205 | GB206 | GB207 | GB20B | GB20C | GR100 | GR102 */ 
+    if (( ((chipHal_HalVarIdx >> 5) == 1UL) && ((1UL << (chipHal_HalVarIdx & 0x1f)) & 0x01f0fc00UL) ) ||
+        ( ((chipHal_HalVarIdx >> 5) == 1UL) && ((1UL << (chipHal_HalVarIdx & 0x1f)) & 0xbc000000UL) ) ||
+        ( ((chipHal_HalVarIdx >> 5) == 2UL) && ((1UL << (chipHal_HalVarIdx & 0x1f)) & 0x000030ffUL) )) /* ChipHal: GA100 | GA102 | GA103 | GA104 | GA106 | GA107 | AD102 | AD103 | AD104 | AD106 | AD107 | GH100 | GB100 | GB102 | GB10B | GB110 | GB112 | GB202 | GB203 | GB205 | GB206 | GB207 | GB20B | GB20C | GR100 | GR102 */
     {
         pThis->__dmaAllocBar1P2PMapping__ = &dmaAllocBar1P2PMapping_GH100;
     }
@@ -342,8 +343,9 @@ static void __nvoc_init_funcTable_VirtMemAllocator_1(VirtMemAllocator *pThis, Gp
     }
 
     // dmaFreeBar1P2PMapping -- halified (2 hals) body
-    if (( ((chipHal_HalVarIdx >> 5) == 1UL) && ((1UL << (chipHal_HalVarIdx & 0x1f)) & 0xbc000000UL) ) ||
-        ( ((chipHal_HalVarIdx >> 5) == 2UL) && ((1UL << (chipHal_HalVarIdx & 0x1f)) & 0x000030ffUL) )) /* ChipHal: GH100 | GB100 | GB102 | GB10B | GB110 | GB112 | GB202 | GB203 | GB205 | GB206 | GB207 | GB20B | GB20C | GR100 | GR102 */ 
+    if (( ((chipHal_HalVarIdx >> 5) == 1UL) && ((1UL << (chipHal_HalVarIdx & 0x1f)) & 0x01f0fc00UL) ) ||
+        ( ((chipHal_HalVarIdx >> 5) == 1UL) && ((1UL << (chipHal_HalVarIdx & 0x1f)) & 0xbc000000UL) ) ||
+        ( ((chipHal_HalVarIdx >> 5) == 2UL) && ((1UL << (chipHal_HalVarIdx & 0x1f)) & 0x000030ffUL) )) /* ChipHal: GA100 | GA102 | GA103 | GA104 | GA106 | GA107 | AD102 | AD103 | AD104 | AD106 | AD107 | GH100 | GB100 | GB102 | GB10B | GB110 | GB112 | GB202 | GB203 | GB205 | GB206 | GB207 | GB20B | GB20C | GR100 | GR102 */
     {
         pThis->__dmaFreeBar1P2PMapping__ = &dmaFreeBar1P2PMapping_GH100;
     }
@@ -528,4 +530,3 @@ NV_STATUS __nvoc_objCreateDynamic_VirtMemAllocator(Dynamic **__nvoc_ppThis, Dyna
 
     return __nvoc_objCreate_VirtMemAllocator((VirtMemAllocator **) __nvoc_ppThis, __nvoc_pParent, __nvoc_createFlags);
 }
-

--- a/src/nvidia/inc/kernel/rmapi/mapping_list.h
+++ b/src/nvidia/inc/kernel/rmapi/mapping_list.h
@@ -66,6 +66,7 @@ struct _def_client_dma_mapping_info
     ADDRESS_TRANSLATION   addressTranslation;
     MEMORY_DESCRIPTOR    *pBar1P2PVirtMemDesc;              // The peer GPU mapped BAR1 region
     MEMORY_DESCRIPTOR    *pBar1P2PPhysMemDesc;              // The peer GPU vidmem sub region
+    NvU64                 bar1P2PApertureOffset;             // Offset of the dynamic peer mapping in BAR1
     CLI_DMA_MAPPING_INFO *pNext;
 };
 

--- a/src/nvidia/interface/nvrm_registry.h
+++ b/src/nvidia/interface/nvrm_registry.h
@@ -911,6 +911,16 @@
 
 //
 // TYPE DWORD
+// Trims the top of the usable FB by the given number of MiB so boards where
+// BAR1 size equals VRAM size can satisfy the static BAR1 P2P requirement
+// (BAR1 >= clientFB + 512 MiB console/mailbox alignment floor).
+//
+#define NV_REG_STR_RM_P2P_FB_TAIL_RESERVE_MB                  "RMP2PFbTailReserveMb"
+#define NV_REG_STR_RM_P2P_FB_TAIL_RESERVE_MB_DISABLED         0x0
+#define NV_REG_STR_RM_P2P_FB_TAIL_RESERVE_MB_ADAPTIVE         0x1
+
+//
+// TYPE DWORD
 // This regkey overrides the max context size (used to determine the reserved memory size) to a user-specified value.
 // Exposed to clients for bug 5201785. For internal use only.
 // The value must be greater than 0 and less than the calculated max context size for the regkey to take effect.    .

--- a/src/nvidia/src/kernel/gpu/mem_mgr/arch/hopper/virt_mem_allocator_gh100.c
+++ b/src/nvidia/src/kernel/gpu/mem_mgr/arch/hopper/virt_mem_allocator_gh100.c
@@ -57,6 +57,7 @@ dmaAllocBar1P2PMapping_GH100
     OBJGPU *pPeerGpu = NULL;
     KernelBus *pPeerKernelBus = NULL;
     NV_STATUS status = NV_OK;
+    NvBool bBar1Mapped = NV_FALSE;
 
     if (params == NULL ||
         params->pVas == NULL ||
@@ -94,6 +95,8 @@ dmaAllocBar1P2PMapping_GH100
     if (status != NV_OK)
         goto cleanup;
 
+    bBar1Mapped = NV_TRUE;
+
     bar1PhyAddr = gpumgrGetGpuPhysFbAddr(pPeerGpu) + phyAddr;
 
     NV_PRINTF(LEVEL_INFO, "bar1p2p surface mapped at bar1PhyAddr 0x%llx, len 0x%llx\n",
@@ -127,6 +130,7 @@ dmaAllocBar1P2PMapping_GH100
 
     params->pDmaMappingInfo->pBar1P2PVirtMemDesc = pBar1P2PVirtMemDesc;
     params->pDmaMappingInfo->pBar1P2PPhysMemDesc = pBar1P2PPhysMemDesc;
+    params->pDmaMappingInfo->bar1P2PApertureOffset = phyAddr;
 
     // Save the MemDesc to be the newly created sysmem in the peer BAR1 aperture
     params->pMemDescOut = pBar1P2PVirtMemDesc;
@@ -147,10 +151,10 @@ dmaAllocBar1P2PMapping_GH100
     return NV_OK;;
 
 cleanup:
-    if (phyAddr != 0)
+    if (bBar1Mapped)
     {
         kbusUnmapFbApertureSingle(pPeerGpu, pPeerKernelBus,
-                                  params->pPeerMemDesc,
+                                  pBar1P2PPhysMemDesc,
                                   phyAddr,
                                   bar1ApertureLen,
                                   BUS_MAP_FB_FLAGS_MAP_UNICAST);
@@ -186,17 +190,18 @@ dmaFreeBar1P2PMapping_GH100
     {
         OBJGPU *pPeerGpu = pDmaMappingInfo->pBar1P2PPhysMemDesc->pGpu;
         KernelBus *pPeerKernelBus = GPU_GET_KERNEL_BUS(pPeerGpu);
-        NvU64   bar1PhysAddr = memdescGetPhysAddr(pDmaMappingInfo->pBar1P2PVirtMemDesc, AT_CPU, 0);
+        NvU64   bar1ApertureOffset = pDmaMappingInfo->bar1P2PApertureOffset;
         NvU64   bar1MapSize  = memdescGetSize(pDmaMappingInfo->pBar1P2PVirtMemDesc);
 
         // Unmap the BAR1 mapping
         kbusUnmapFbApertureSingle(pPeerGpu, pPeerKernelBus,
                                   pDmaMappingInfo->pBar1P2PPhysMemDesc,
-                                  bar1PhysAddr,
+                                  bar1ApertureOffset,
                                   bar1MapSize,
                                   BUS_MAP_FB_FLAGS_MAP_UNICAST);
 
-        NV_PRINTF(LEVEL_INFO, "bar1p2p surface UN-mapped at 0x%llx + 0x%llx\n", bar1PhysAddr, bar1MapSize);
+        NV_PRINTF(LEVEL_INFO, "bar1p2p surface UN-mapped at 0x%llx + 0x%llx\n",
+                              bar1ApertureOffset, bar1MapSize);
 
         // Destroy the source memory descriptor
         memdescDestroy(pDmaMappingInfo->pBar1P2PPhysMemDesc);

--- a/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr_gsp_client.c
+++ b/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr_gsp_client.c
@@ -29,7 +29,193 @@
 #include "gpu/gsp/gsp_static_config.h"
 #include <ctrl/ctrl2080/ctrl2080fb.h>
 #include "gpu/mem_mgr/fermi_dma.h"
+#include "gpu/mem_mgr/rm_page_size.h"
+#include "nvrm_registry.h"
 #include "nvoc/prelude.h"
+
+/*!
+ * @brief Size BAR1 directly via PCI config space (write-ones probe), because
+ *        KernelBus->pciBarSizes[] is not populated yet when the GSP FB region
+ *        table is parsed. Uses the same osPci* accessors as kern_gpu_gb202.c,
+ *        but does not cache the handle in pGpu->hPci.
+ */
+static NvU64
+_p2pPciBar1Size
+(
+    OBJGPU *pGpu
+)
+{
+    void *h = pGpu->hPci;
+    NvU32 cmd, lo, hi, slo, shi;
+    NvU64 size;
+    NvBool bBar1Is64;
+
+    if (h == NULL)
+    {
+        h = osPciInitHandle(gpuGetDomain(pGpu), gpuGetBus(pGpu),
+                            gpuGetDevice(pGpu), 0 /* function */, NULL, NULL);
+    }
+    if (h == NULL)
+        return 0;
+
+    lo = osPciReadDword(h, 0x14);
+    bBar1Is64 = ((lo & 0x4) != 0);
+    hi = bBar1Is64 ? osPciReadDword(h, 0x18) : 0;
+
+    cmd = osPciReadDword(h, 0x04);
+
+    // Temporarily disable memory space decoding while sizing the BAR.
+    osPciWriteDword(h, 0x04, cmd & ~0x2);
+
+    osPciWriteDword(h, 0x14, 0xFFFFFFFF);
+    if (bBar1Is64)
+        osPciWriteDword(h, 0x18, 0xFFFFFFFF);
+    slo = osPciReadDword(h, 0x14) & ~0xFu;
+    shi = bBar1Is64 ? osPciReadDword(h, 0x18) : 0;
+
+    osPciWriteDword(h, 0x14, lo);
+    if (bBar1Is64)
+        osPciWriteDword(h, 0x18, hi);
+
+    osPciWriteDword(h, 0x04, cmd);
+
+    if ((slo == 0) && (shi == 0))
+        return 0;
+
+    size = ~(((NvU64)shi << 32) | (NvU64)slo) + 1;
+    return (size == 0) ? 0 : size;
+}
+
+//
+// Registry key RMP2PFbTailReserveMb (see nvrm_registry.h):
+//   0 (default) - disabled, no trim
+//   1           - adaptive per-GPU trim (exactly the static BAR1 shortfall)
+//   N (>1)      - fixed trim of N MiB
+//
+#define P2P_FB_TAIL_RESERVE_MARGIN_BYTES (16ULL << 20)
+
+/*!
+ * @brief Trim the top of the usable FB by a registry-controlled amount so
+ *        boards whose BAR1 size equals their VRAM size can satisfy the
+ *        static BAR1 P2P requirement.
+ *
+ *        The static BAR1 requirement (BAR1 >= clientFB + 512 MiB alignment
+ *        floor for the console/mailbox area) misses by only a few MiB when
+ *        BAR1 == VRAM (e.g. 16 GiB / 16 GiB), so BAR1 P2P can never be
+ *        enabled on such boards. Trimming the top of the usable FB by the
+ *        shortfall makes the requirement fit, at the cost of that much
+ *        usable VRAM (per GPU).
+ *
+ *        The trim folds the top of the topmost usable region into the
+ *        reserved region directly above it (the GSP layout always reserves
+ *        the top of the FB), so the heap/PMA can never allocate it. A usable
+ *        region on top of the FB is left untrimmed (with a warning), since
+ *        shrinking the top region would understate fbAddrSpaceSizeMb.
+ */
+static void
+_p2pApplyFbTailReserve
+(
+    OBJGPU        *pGpu,
+    MemoryManager *pMemoryManager,
+    NvU32          numFBRegions
+)
+{
+    NvU32  tailReserveMb = 0;
+    NvU32  last          = numFBRegions - 1;
+    NvU32  u;
+    NvU64  trimBytes     = 0;
+    NvU64  bar1Size;
+    NvBool bTrimmed      = NV_FALSE;
+
+    if ((osReadRegistryDword(pGpu, NV_REG_STR_RM_P2P_FB_TAIL_RESERVE_MB, &tailReserveMb) != NV_OK) ||
+        (tailReserveMb == NV_REG_STR_RM_P2P_FB_TAIL_RESERVE_MB_DISABLED))
+    {
+        return;
+    }
+
+    if (tailReserveMb == NV_REG_STR_RM_P2P_FB_TAIL_RESERVE_MB_ADAPTIVE)
+    {
+        //
+        // Adaptive: trim exactly what static BAR1 needs on this GPU,
+        // assuming the worst case 512 MiB console/mailbox alignment floor
+        // (so the GPU stays P2P-capable even if it later drives a display),
+        // plus margin for the BAR1-mappable length being slightly below the
+        // PCI BAR size. GPUs that already fit are not trimmed at all.
+        //
+        bar1Size = _p2pPciBar1Size(pGpu);
+        if (bar1Size == 0)
+        {
+            KernelBus *pKernelBus = GPU_GET_KERNEL_BUS(pGpu);
+
+            bar1Size = (pKernelBus != NULL) ? kbusGetPciBarSize(pKernelBus, 1) : 0;
+        }
+
+        if (bar1Size == 0)
+        {
+            NV_PRINTF(LEVEL_WARNING,
+                      "P2P FB tail reserve: BAR1 size unknown, skipping adaptive trim\n");
+            return;
+        }
+
+        NvU64 bar1Usable = RM_ALIGN_DOWN(bar1Size, RM_PAGE_SIZE_2M);
+        NvU64 required   = pMemoryManager->Ram.fbUsableMemSize + RM_PAGE_SIZE_512M;
+
+        if (required > bar1Usable)
+        {
+            trimBytes = RM_ALIGN_UP(required + P2P_FB_TAIL_RESERVE_MARGIN_BYTES - bar1Usable,
+                                    RM_PAGE_SIZE_2M);
+        }
+    }
+    else
+    {
+        trimBytes = (NvU64)tailReserveMb << 20;
+    }
+
+    if ((trimBytes == 0) || (last < 1))
+    {
+        return;
+    }
+
+    //
+    // Fold the trim into the reserved region on top of the FB: find the
+    // topmost usable region below the reserved region(s) at the top (the GSP
+    // layout always reserves the top of the FB), trim that region's limit,
+    // and extend the reserved region directly above it downward, keeping the
+    // region chain contiguous. A usable region on top of the FB is left
+    // untrimmed, since shrinking the top region would understate
+    // fbAddrSpaceSizeMb, which is derived from the top region's limit below.
+    //
+    if (pMemoryManager->Ram.fbRegion[last].bRsvdRegion)
+    {
+        u = last;
+        while ((u != 0) && pMemoryManager->Ram.fbRegion[u].bRsvdRegion)
+        {
+            u--;
+        }
+
+        if (!pMemoryManager->Ram.fbRegion[u].bRsvdRegion &&
+            pMemoryManager->Ram.fbRegion[u + 1].bRsvdRegion &&
+            (pMemoryManager->Ram.fbRegion[u + 1].base ==
+                pMemoryManager->Ram.fbRegion[u].limit + 1) &&
+            (pMemoryManager->Ram.fbRegion[u].limit -
+             pMemoryManager->Ram.fbRegion[u].base + 1) > trimBytes)
+        {
+            pMemoryManager->Ram.fbRegion[u].limit       -= trimBytes;
+            pMemoryManager->Ram.fbRegion[u + 1].base    -= trimBytes;
+            pMemoryManager->Ram.fbRegion[u + 1].rsvdSize += trimBytes;
+            pMemoryManager->Ram.fbUsableMemSize         -= trimBytes;
+            pMemoryManager->Ram.reservedMemSize         += trimBytes;
+            bTrimmed = NV_TRUE;
+        }
+    }
+
+    if (!bTrimmed)
+    {
+        NV_PRINTF(LEVEL_WARNING,
+                  "P2P FB tail reserve: no trimmable usable region found below the reserved top, skipping 0x%llx byte trim\n",
+                  trimBytes);
+    }
+}
 
 /*!
  * @brief Initialize FB regions from static info obtained from GSP FW. Also,
@@ -106,6 +292,13 @@ memmgrInitBaseFbRegions_FWCLIENT
         }
     }
     pMemoryManager->Ram.numFBRegions = pFbRegionInfoParams->numFBRegions;
+
+    //
+    // P2P tail reserve: optionally trim the top of the usable FB (see
+    // _p2pApplyFbTailReserve) so BAR1 == VRAM boards can pass the static
+    // BAR1 P2P check.
+    //
+    _p2pApplyFbTailReserve(pGpu, pMemoryManager, pFbRegionInfoParams->numFBRegions);
 
     // Round up to the closest megabyte.
     bias = (1 << 20) - 1;

--- a/src/nvidia/src/kernel/platform/p2p/p2p_caps.c
+++ b/src/nvidia/src/kernel/platform/p2p/p2p_caps.c
@@ -66,6 +66,36 @@ areGpusP2PCompatible(OBJGPU *pGpu0, OBJGPU *pGpu1)
     return NV_TRUE;
 }
 
+/**
+ * @brief Determines if all GPUs can use the proprietary PCIe P2P protocol
+ *
+ * Static BAR1 P2P does not exchange the architecture-specific mailbox
+ * protocol, so this compatibility check must only gate the proprietary PCIe
+ * fallback.
+ */
+static NvBool
+areAllGpusP2PCompatible(NvU32 gpuMask)
+{
+    NvU32 gpuInstance = 0;
+    OBJGPU *pGpu;
+    OBJGPU *pFirstGpu = gpumgrGetNextGpu(gpuMask, &gpuInstance);
+
+    if (pFirstGpu == NULL)
+    {
+        return NV_FALSE;
+    }
+
+    while ((pGpu = gpumgrGetNextGpu(gpuMask, &gpuInstance)) != NULL)
+    {
+        if (!areGpusP2PCompatible(pFirstGpu, pGpu))
+        {
+            return NV_FALSE;
+        }
+    }
+
+    return NV_TRUE;
+}
+
 NV_STATUS
 p2pGetCaps
 (
@@ -896,33 +926,41 @@ p2pGetCapsStatus
     }
 
     //
-    // Check PCIE P2P connectivity.
-    //
-    // We can control P2P connectivity for PCI-E peers using regkeys, hence
-    // if either read or write is supported, return success. See
-    // _kp2pCapsCheckStatusOverridesForPcie for details.
+    // Check PCIe topology and proprietary P2P capabilities first to retain
+    // its common-switch result. BAR1 is a separate transport, so check it
+    // with fresh status even when proprietary compatibility failed.
     //
     if (_kp2pCapsGetStatusOverPcie(gpuMask, pP2PWriteCapStatus,
                                   pP2PReadCapStatus, &bCommonSwitchFound) == NV_OK)
     {
+        NvU8 bar1P2PWriteCapStatus = NV0000_P2P_CAPS_STATUS_OK;
+        NvU8 bar1P2PReadCapStatus = NV0000_P2P_CAPS_STATUS_OK;
+        NvU8 bar1P2PAtomicsCapStatus = NV0000_P2P_CAPS_STATUS_NOT_SUPPORTED;
+
+        if (_kp2pCapsGetStatusOverPcieBar1(gpuMask, &bar1P2PWriteCapStatus,
+                &bar1P2PReadCapStatus, &bar1P2PAtomicsCapStatus,
+                bCommonSwitchFound) == NV_OK)
+        {
+            *pP2PWriteCapStatus = bar1P2PWriteCapStatus;
+            *pP2PReadCapStatus = bar1P2PReadCapStatus;
+            *pP2PAtomicsCapStatus = bar1P2PAtomicsCapStatus;
+            *pConnectivity = P2P_CONNECTIVITY_PCIE_BAR1;
+            return NV_OK;
+        }
+
+        // BAR1 is the only architecture-independent PCIe transport here.
+        if (!areAllGpusP2PCompatible(gpuMask))
+        {
+            *pP2PWriteCapStatus = NV0000_P2P_CAPS_STATUS_NOT_SUPPORTED;
+            *pP2PReadCapStatus = NV0000_P2P_CAPS_STATUS_NOT_SUPPORTED;
+            *pP2PAtomicsCapStatus = NV0000_P2P_CAPS_STATUS_NOT_SUPPORTED;
+            return NV_OK;
+        }
+
         if ((*pP2PWriteCapStatus == NV0000_P2P_CAPS_STATUS_OK) ||
             (*pP2PReadCapStatus == NV0000_P2P_CAPS_STATUS_OK))
         {
-            NvU8 bar1P2PWriteCapStatus = *pP2PWriteCapStatus;
-            NvU8 bar1P2PReadCapStatus = *pP2PReadCapStatus;
-            NvU8 bar1P2PAtomicsCapStatus = NV0000_P2P_CAPS_STATUS_NOT_SUPPORTED;
-
             *pConnectivity = P2P_CONNECTIVITY_PCIE_PROPRIETARY;
-
-            if (_kp2pCapsGetStatusOverPcieBar1(gpuMask, &bar1P2PWriteCapStatus,
-                    &bar1P2PReadCapStatus, &bar1P2PAtomicsCapStatus, bCommonSwitchFound) == NV_OK)
-            {
-                *pP2PWriteCapStatus = bar1P2PWriteCapStatus;
-                *pP2PReadCapStatus = bar1P2PReadCapStatus;
-                *pP2PAtomicsCapStatus = bar1P2PAtomicsCapStatus;
-                *pConnectivity = P2P_CONNECTIVITY_PCIE_BAR1;
-            }
-
             return NV_OK;
         }
     }

--- a/src/nvidia/src/kernel/platform/p2p/p2p_caps.c
+++ b/src/nvidia/src/kernel/platform/p2p/p2p_caps.c
@@ -765,7 +765,13 @@ _kp2pCapsGetStatusOverPcieBar1
     // Re-initialize to check loop back configuration if only single GPU in
     // requested mask.
     //
-    gpuInstance = (gpumgrGetSubDeviceCount(gpuMask) > 1) ? gpuInstance : 0;
+    // Count the GPUs in the mask directly. gpumgrGetSubDeviceCount() counts
+    // SLI subdevices, which is 1 for unlinked GPUs, so the old check reset
+    // the iterator for every non-SLI pair and each evaluation started with a
+    // self/loopback check that the HAL rejects. BAR1 P2P caps could then
+    // never succeed on non-SLI multi-GPU systems.
+    //
+    gpuInstance = (nvPopCount32(gpuMask) > 1) ? gpuInstance : 0;
 
     while ((pGpuPeer = gpumgrGetNextGpu(gpuMask, &gpuInstance)) != NULL)
     {

--- a/src/nvidia/src/kernel/rmapi/nv_gpu_ops.c
+++ b/src/nvidia/src/kernel/rmapi/nv_gpu_ops.c
@@ -3241,15 +3241,29 @@ static NV_STATUS getNvlinkP2PCaps(struct gpuDevice *device1,
 }
 
 // TODO: Bug 3264814: [HOPPER][RM] Support Bar1 P2P PCIE Atomics
-// The logic here should consider bus topology and routing between
-// the two GPUs.
+// The logic here should consider bus topology and routing between the two
+// GPUs. Mixed-architecture BAR1 mappings must remain non-coherent until that
+// routing and the atomic protocol compatibility have been validated.
 NvBool _nvGpuOpsIsBar1P2pAtomicEnabled(struct gpuSession *session, OBJGPU *pMappingGpu, OBJGPU *pOwningGpu)
 {
-    NvU32 arch;
-    NV_STATUS status = _nvGpuOpsGetDeviceArchByGpuId(session, pOwningGpu->gpuId, &arch);
+    NvU32 mappingArch;
+    NvU32 owningArch;
+    NV_STATUS status = _nvGpuOpsGetDeviceArchByGpuId(session, pOwningGpu->gpuId, &owningArch);
 
     NV_ASSERT_OR_RETURN(status == NV_OK, 0);
-    return arch >= GPU_ARCHITECTURE_BLACKWELL_GB1XX;
+
+    if (pMappingGpu != NULL)
+    {
+        status = _nvGpuOpsGetDeviceArchByGpuId(session, pMappingGpu->gpuId, &mappingArch);
+        NV_ASSERT_OR_RETURN(status == NV_OK, 0);
+
+        if (mappingArch != owningArch)
+        {
+            return NV_FALSE;
+        }
+    }
+
+    return owningArch >= GPU_ARCHITECTURE_BLACKWELL_GB1XX;
 }
 
 NV_STATUS nvGpuOpsGetP2PCaps(struct gpuDevice *device1,
@@ -3667,6 +3681,7 @@ done:
 }
 
 static GMMU_APERTURE nvGpuOpsGetExternalAllocAperture(struct gpuSession *session,
+                                                      OBJGPU *pMappingGpu,
                                                       PMEMORY_DESCRIPTOR pMemDesc,
                                                       NvBool isIndirectPeerSupported,
                                                       NvBool isPeerSupported,
@@ -3684,7 +3699,7 @@ static GMMU_APERTURE nvGpuOpsGetExternalAllocAperture(struct gpuSession *session
 
         if (isBar1P2PSupported)
         {
-            if (_nvGpuOpsIsBar1P2pAtomicEnabled(session, NULL, pMemDesc->pGpu))
+            if (_nvGpuOpsIsBar1P2pAtomicEnabled(session, pMappingGpu, pMemDesc->pGpu))
             {
                 return GMMU_APERTURE_SYS_COH;
             }
@@ -4101,6 +4116,7 @@ nvGpuOpsBuildExternalAllocPtes
         memdescSetPteKindForGpu(pMemDesc, pMappingGpu, oldKind);
 
     aperture = nvGpuOpsGetExternalAllocAperture(session,
+                                                pMappingGpu,
                                                 pMemDesc,
                                                 isIndirectPeerSupported,
                                                 isPeerSupported,
@@ -4525,6 +4541,7 @@ nvGpuOpsBuildExternalAllocPhysAddrs
         return NV_ERR_INVALID_ARGUMENT;
 
     aperture = nvGpuOpsGetExternalAllocAperture(session,
+                                                pMappingGpu,
                                                 pMemDesc,
                                                 isIndirectPeerSupported,
                                                 isPeerSupported,
@@ -8119,6 +8136,7 @@ static NV_STATUS nvGpuOpsFillGpuMemoryInfo(PMEMORY_DESCRIPTOR pMemDesc,
     if (pGpuMemoryInfo->contig)
     {
         GMMU_APERTURE aperture = nvGpuOpsGetExternalAllocAperture(NULL,
+                                                                  pMappingGpu,
                                                                   pMemDesc,
                                                                   NV_FALSE,
                                                                   NV_FALSE,


### PR DESCRIPTION
# Static BAR1 P2P on BAR1 == VRAM boards: adaptive FB tail reserve + caps loopback fix

## What

This enables PCIe BAR1 peer-to-peer between consumer GPUs whose BAR1 size equals their VRAM size (e.g. two 16 GiB-BAR1 / 16 GiB-VRAM boards such as RTX 5070 Ti + RTX 5060 Ti), and fixes an RM bug that made BAR1 P2P capability evaluation always fail on non-SLI multi-GPU systems.

Two changes:

1. **`RMP2PFbTailReserveMb` registry key** (default off — zero behavior change when unset)
2. **Loopback iterator fix** in `_kp2pCapsGetStatusOverPcieBar1()` (pure bugfix)

## Why BAR1 == VRAM boards can't do static BAR1 P2P

The static BAR1 path (extending PR #36's display-aware sizing) requires

```
BAR1 >= clientFB + 512 MiB alignment floor   (floor = NV_ALIGN_UP(console + mailbox, 512 MiB))
```

On boards where BAR1 == VRAM there is no headroom: the 5070 Ti with a 3 MiB
boot console takes the 512 MiB floor and misses the requirement by **10 MiB**.
P2P can never be enabled no matter what the other GPU looks like. (Boards with
smaller BAR1 than VRAM, the usual case, have hundreds of MiB of slack and are
unaffected — see issue #39.)

## Change 1: `RMP2PFbTailReserveMb`

Set via `NVreg_RegistryDwords`:

| value | meaning |
|---|---|
| absent / 0 | disabled (default) |
| 1 | **adaptive**: trim exactly this GPU's static BAR1 shortfall, assuming the worst-case 512 MiB console/mailbox floor (+16 MiB margin, rounded up to 2 MiB) — the GPU stays P2P-capable even while driving a display. GPUs that already fit are **not** trimmed at all. |
| N > 1 | fixed trim of N MiB |

The trim takes the top of the topmost usable FB region at GSP FB region-table
parse time (`memmgrInitBaseFbRegions_FWCLIENT`) and folds it into the adjacent
reserved region (the GSP layout always reserves the top of the FB), keeping
`fbUsableMemSize` / `reservedMemSize` and the region chain consistent, so the
heap/PMA/clientFB never see the trimmed tail. An FB that ends in a usable
region is left untrimmed with a WARNING (shrinking the top region would
understate `fbAddrSpaceSizeMb`).

BAR1 has to be sized before `KernelBus->pciBarSizes[]` is populated, so the
adaptive path sizes it with a PCI config write-ones probe (`osPci*`, same
pattern as `kern_gpu_gb202.c`), with `kbusGetPciBarSize()` as a fallback.

```conf
# /etc/modprobe.d/nvidia-p2p.conf
options nvidia NVreg_RegistryDwords="RMP2PFbTailReserveMb=1"
```

## Change 2: caps loopback bug (upstream since 580.65.06)

`_kp2pCapsGetStatusOverPcieBar1()` decides whether its mask holds a single GPU
(so it should loop back onto itself for the self-check) using
`gpumgrGetSubDeviceCount()`. That counts **SLI subdevices**, which is 1 for
unlinked GPUs — so on every non-SLI multi-GPU system the iterator was reset and
each pair evaluation started with a GPU-vs-itself check, which the HAL rejects
as loopback. Real pairs were never evaluated and BAR1 P2P caps always failed,
even when the BAR1 sizing fits. Fixed by counting the GPUs in the mask
directly: `nvPopCount32(gpuMask) > 1`.

## Verification

RTX 5070 Ti (GB203, CPU slot) + RTX 5060 Ti (GB206, chipset x4), driver
`610.57.04-p2p-v2` + this branch, `RMP2PFbTailReserveMb=1`:

| | GPU0 (5070 Ti) | GPU1 (5060 Ti) |
|---|---|---|
| BAR1 mappable | 16,382 MiB | 16,382 MiB |
| clientFB | 15,880 MiB | 15,888 MiB |
| console / mailbox | 3 MiB / 0 | 0 / 0 |
| static floor | 512 MiB | 0 |
| pre-fix verdict | misses by 10 MiB | fits |
| adaptive trim | **150 MiB** | **160 MiB** |

```
canAccessPeer: 0->1 = 1, 1->0 = 1
enablePeerAccess: no error, both directions
direct SM peer write GPU0 -> GPU1: OK (data verified through peer mapping)
```
## Notes

- The regkey is per-GPU evaluated; multi-GPU systems with mixed fit/no-fit
  boards trim only the boards that need it. Over-trimming is deliberate
  (worst-case 512 MiB floor + 16 MiB margin, rounded to 2 MiB) so a console
  coming up later can't silently kill P2P.
- If the BAR1 size cannot be determined (PCI probe and
  `kbusGetPciBarSize()` both fail) the adaptive trim is skipped with a
  WARNING rather than guessing.
- A third blocker exists for some pairs (e.g. GB203↔GB206): the per-device
  class table in libcuda — userspace, handled by this fork's
  `patch-libcuda-p2p.py`, out of scope for this kernel-side PR.

Refs: #36 (display-aware static BAR1 sizing), #39 (5060 Ti P2P margin luck).
